### PR TITLE
updated deployment files w/ new registry

### DIFF
--- a/multichain-node/deployment/base/deployment.yaml
+++ b/multichain-node/deployment/base/deployment.yaml
@@ -8,12 +8,15 @@ spec:
     spec:
       containers:
       - name: multichain-node
-        image: sensrnetregistry.azurecr.io/sensrnet/multichain-node:latest
+        image: sensrnetnl/multichain-node:latest
         env:
         - name: CHAINNAME
           value: MyChain
         - name: MASTER_NODE_HOST
-          value: 20.54.161.4
+          valueFrom:
+              secretKeyRef:
+                name: multichain-settings
+                key: host
         - name: NETWORK_PORT
           value: "7557"
         - name: RPC_ALLOW_IP

--- a/multichain-node/deployment/overlays/test/kustomization.yaml
+++ b/multichain-node/deployment/overlays/test/kustomization.yaml
@@ -1,9 +1,6 @@
 bases:
 - ../../base
 
-resources:
-- storageclass.yaml
-
 patchesStrategicMerge:
 - deployment.yaml
 - pvc.yaml

--- a/multichain-node/deployment/overlays/test/storageclass.yaml
+++ b/multichain-node/deployment/overlays/test/storageclass.yaml
@@ -1,9 +1,0 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: managed-premium-retain
-provisioner: kubernetes.io/azure-disk
-reclaimPolicy: Retain
-parameters:
-  storageaccounttype: Premium_LRS
-  kind: Managed


### PR DESCRIPTION
Changed the registry from the private ACR (Azure Container Registry) to the
publicly accessible Docker Hub.

Also, the storageclass.yaml has been removed as it belongs in the ops repo.

Links to https://github.com/kadaster-labs/sensrnet-ops/issues/24