### PR TITLE
chore: remove old Explorer requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-py-ubjson==0.16.1
-pycrypto==2.6.1


### PR DESCRIPTION
MultiChain Explorer is Python application, which we previously included in our Docker image. The requirements.txt still floated around in our repo, without being used. Dependabot, however, detected critical bugs in the dependencies. Therefore, remove the old file, so we don't get the warning anymore and it wasn't used anyway