### PR TITLE
build: add Trivy in CI for Docker Image Scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Build image from Dockerfile
-        run: |
-          docker build -t docker.io/sensrnetnl/multichain-node:${{ github.sha }} .
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: ${{ env.DOCKERHUB_NAMESPACE }}/${{ env.REPOSITORY }}:${{ github.sha }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'docker.io/sensrnetnl/multichain-node:${{ github.sha }}'
+          image-ref: '${{ env.DOCKERHUB_NAMESPACE }}/${{ env.REPOSITORY }}:${{ github.sha }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build image from Dockerfile
+        run: |
+          docker build -t sensrnetnl/multichain-node:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'sensrnetnl/multichain-node:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,10 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  DOCKERHUB_NAMESPACE: sensrnetnl
-  REPOSITORY: multichain-node
-
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
 
       - name: Build image from Dockerfile
         run: |
-          docker build -t sensrnetnl/multichain-node:${{ github.sha }} .
+          docker build -t docker.io/sensrnetnl/multichain-node:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'sensrnetnl/multichain-node:${{ github.sha }}'
+          image-ref: 'docker.io/sensrnetnl/multichain-node:${{ github.sha }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  DOCKERHUB_NAMESPACE: sensrnetnl
+  REPOSITORY: multichain-node
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          tags: ${{ env.DOCKERHUB_NAMESPACE }}/${{ env.REPOSITORY }}:${{ github.sha }}
+      - name: Build image from Dockerfile
+        run: |
+          docker build -t sensrnetnl/multichain-node:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.DOCKERHUB_NAMESPACE }}/${{ env.REPOSITORY }}:${{ github.sha }}'
+          image-ref: 'sensrnetnl/multichain-node:${{ github.sha }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,8 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'sensrnetnl/multichain-node:${{ github.sha }}'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.0
 
 RUN     apk update \
         && apk upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.0
+FROM alpine:3.14
 
 RUN     apk update \
         && apk upgrade \


### PR DESCRIPTION
- Let Trivy scan the Docker Image for High and Critical vulnerabilities. The pipeline will fail if problems are found.

Links to https://github.com/kadaster-labs/sensrnet-ops/issues/46